### PR TITLE
rename mvp name to zMVP

### DIFF
--- a/shaders/floor.vert
+++ b/shaders/floor.vert
@@ -1,10 +1,10 @@
 #version 320 es
 
-uniform mat4 mvp;
+uniform mat4 zMVP;
 layout(location = 0) in vec4 position;
 
 void
 main()
 {
-  gl_Position = mvp * position;
+  gl_Position = zMVP * position;
 }


### PR DESCRIPTION
## Context

https://github.com/zigen-project/zen-remote/pull/59

## Summary

change shader variable name `mvp` to 'zMVP`

